### PR TITLE
Added ios deployment_target

### DIFF
--- a/Apodimark.podspec
+++ b/Apodimark.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
     spec.name         = 'Apodimark'
     spec.version      = '0.4.0'
     spec.osx.deployment_target = "10.12"
-
+    spec.ios.deployment_target = '9.0'
     spec.summary      = 'Fast, flexible Markdown parser in Swift'
     spec.author       = 'Loïc Lecrenier'
     spec.homepage     = 'https://github.com/loiclec/Apodimark.git'


### PR DESCRIPTION
Added the ios deployment target in order to use this library in an ios target. Once you add a osx deployment target it needs its counterpart in order to work.